### PR TITLE
updated Berksfile to help with enterprises

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,4 @@
-source "https://supermarket.chef.io"
+site :opscode
 
 metadata
 

--- a/Berksfile
+++ b/Berksfile
@@ -1,10 +1,10 @@
-site :opscode
+source "https://supermarket.chef.io"
 
 metadata
 
-cookbook 'rs-storage', github:'rightscale-cookbooks/rs-storage'
-cookbook 'rightscale_volume', github:'rightscale-cookbooks/rightscale_volume'
-cookbook 'rightscale_backup', github:'rightscale-cookbooks/rightscale_backup'
-cookbook 'machine_tag', github:'rightscale-cookbooks/machine_tag'
-cookbook 'rsc_ros', github: "RightScale-Services-Cookbooks/rsc_ros", tag:'v0.3.0'
-cookbook 'rsc_postfix', github:"RightScale-Services-Cookbooks/rsc_postfix", tag:'v1.0.0'
+cookbook 'rs-storage', git:'https://github.com/rightscale-cookbooks/rs-storage'
+cookbook 'rightscale_volume', git:'https://github.com/rightscale-cookbooks/rightscale_volume'
+cookbook 'rightscale_backup', git:'https://github.com/rightscale-cookbooks/rightscale_backup'
+cookbook 'machine_tag', git:'https://github.com/rightscale-cookbooks/machine_tag'
+cookbook 'rsc_ros', git: "https://github.com/RightScale-Services-Cookbooks/rsc_ros", tag:'v0.3.0'
+cookbook 'rsc_postfix', git:"https://github.com/RightScale-Services-Cookbooks/rsc_postfix", tag:'v1.0.0'


### PR DESCRIPTION
Using full git urls vs. github urls because git:// protocol uses ssh which some enterprises don't allow outbound ssh.  Using http and https are better for enterprises because they can be proxied out.
